### PR TITLE
Adding a wordRegex to match special characters in symbols

### DIFF
--- a/lib/cljs-doc-view.js
+++ b/lib/cljs-doc-view.js
@@ -79,7 +79,9 @@ class CljsDocView extends HTMLElement {
 
           this.viewUpdatePending = true;
 
-          let word = activeEditor.getWordUnderCursor();
+          let word = activeEditor.getWordUnderCursor({
+            wordRegex: /[A-Za-z0-9\-!?.<>:\/*=+_]+/g
+          });
 
           if (typeof word === 'string') {
             word = word.trim();


### PR DESCRIPTION
Passing a wordRegex to `getWordUnderCursor` should allow for matching words with special characters such as `empty?` and `if-let`.